### PR TITLE
config() is now deprecated in cakephp3.4 

### DIFF
--- a/src/Model/Behavior/Strategy/PropertyStrategy.php
+++ b/src/Model/Behavior/Strategy/PropertyStrategy.php
@@ -4,7 +4,6 @@ namespace PropertyEnum\Model\Behavior\Strategy;
 use CakeDC\Enum\Model\Behavior\Strategy\AbstractStrategy;
 use Cake\Core\Configure;
 
-
 class PropertyStrategy extends AbstractStrategy
 {
     /**

--- a/src/Model/Behavior/Strategy/PropertyStrategy.php
+++ b/src/Model/Behavior/Strategy/PropertyStrategy.php
@@ -2,6 +2,8 @@
 namespace PropertyEnum\Model\Behavior\Strategy;
 
 use CakeDC\Enum\Model\Behavior\Strategy\AbstractStrategy;
+use Cake\Core\Configure;
+
 
 class PropertyStrategy extends AbstractStrategy
 {
@@ -10,6 +12,10 @@ class PropertyStrategy extends AbstractStrategy
      */
     public function enum(array $config = [])
     {
+        if (Configure::version() >= 3.4) {
+            return (array)$this->_table->enums[$this->getConfig('field')];
+        }
+
         return (array)$this->_table->enums[$this->config('field')];
     }
 }


### PR DESCRIPTION
in src/Model/Behavior/Strategy/PropertyStrategy.php

config() is deprecated if cakephp version is more than 3.4
you need to use getConfig() instead