### PR TITLE
fix deprecated error

### DIFF
--- a/src/Model/Behavior/Strategy/PropertyStrategy.php
+++ b/src/Model/Behavior/Strategy/PropertyStrategy.php
@@ -2,6 +2,7 @@
 namespace PropertyEnum\Model\Behavior\Strategy;
 
 use CakeDC\Enum\Model\Behavior\Strategy\AbstractStrategy;
+use Cake\Core\Configure;
 
 class PropertyStrategy extends AbstractStrategy
 {
@@ -10,6 +11,10 @@ class PropertyStrategy extends AbstractStrategy
      */
     public function enum(array $config = [])
     {
+        if (Configure::version() >= 3.4) {
+            return (array)$this->_table->enums[$this->getConfig('field')];
+        }
+
         return (array)$this->_table->enums[$this->config('field')];
     }
 }


### PR DESCRIPTION
combined methods are now deprecated in ver cakephp 3.4 onwards
